### PR TITLE
#152 bounding box

### DIFF
--- a/crabpy_pyramid/renderers/crab.py
+++ b/crabpy_pyramid/renderers/crab.py
@@ -303,7 +303,7 @@ def item_straat_adapter(obj, request):
                 'definitie': obj.metadata.begin_organisatie.definitie
             }
         },
-        'bounding_box': obj.bounding_box
+        'bounding_box': [float(i) for i in obj.bounding_box]
     }
 
 


### PR DESCRIPTION
convert bounding box to float voor straten. 

Not sure waarom dat enkel bij straten strings zijn, in crabpy vind ik ook niet direct een antwoord :man_shrugging: , maar heb ze hier gwn geconverteerd naar floats